### PR TITLE
feat: properly handle hexagonal maps

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -456,7 +456,29 @@ fn load_map(
             };
 
             let map_type = match tiled_map.map.orientation {
-                tiled::Orientation::Hexagonal => TilemapType::Hexagon(HexCoordSystem::Row),
+                tiled::Orientation::Hexagonal => match tiled_map.map.stagger_axis {
+                    tiled::StaggerAxis::X
+                        if tiled_map.map.stagger_index == tiled::StaggerIndex::Even =>
+                    {
+                        TilemapType::Hexagon(HexCoordSystem::ColumnOdd)
+                    }
+                    tiled::StaggerAxis::X
+                        if tiled_map.map.stagger_index == tiled::StaggerIndex::Odd =>
+                    {
+                        TilemapType::Hexagon(HexCoordSystem::ColumnEven)
+                    }
+                    tiled::StaggerAxis::Y
+                        if tiled_map.map.stagger_index == tiled::StaggerIndex::Even =>
+                    {
+                        TilemapType::Hexagon(HexCoordSystem::RowOdd)
+                    }
+                    tiled::StaggerAxis::Y
+                        if tiled_map.map.stagger_index == tiled::StaggerIndex::Odd =>
+                    {
+                        TilemapType::Hexagon(HexCoordSystem::RowEven)
+                    }
+                    _ => unreachable!(),
+                },
                 tiled::Orientation::Isometric => TilemapType::Isometric(IsoCoordSystem::Diamond),
                 tiled::Orientation::Staggered => TilemapType::Isometric(IsoCoordSystem::Staggered),
                 tiled::Orientation::Orthogonal => TilemapType::Square,


### PR DESCRIPTION
Hi,

Wanted to try your crate to work with "flat-top" hex maps but it did not load properly.
All that was needed was to initialize the tilemap_ecs backend with the proper `TilemapType`.
Now it works properly ! :)

I'm not sure why I had to swap the `Even`and `Odd` settings, but it seems I'm not the first one and others had to do the same: 
- https://github.com/StarArawn/bevy_ecs_tilemap/issues/403
- https://github.com/StarArawn/bevy_ecs_tilemap/pull/405