### PR TITLE
Adds support for transforming TilemapBundle using (0, 0) as the center

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -48,7 +48,7 @@ use bevy::{
 use bevy_ecs_tilemap::prelude::*;
 use tiled::{ChunkData, FiniteTileLayer, InfiniteTileLayer, LayerType, Tile, Tileset};
 
-use crate::prelude::TiledMapSettings;
+use crate::prelude::{MapPositioning, TiledMapSettings};
 
 #[derive(Default)]
 pub struct TiledMapPlugin;
@@ -538,7 +538,19 @@ fn load_map(
                             texture: tilemap_texture.clone(),
                             tile_size,
                             spacing: tile_spacing,
-                            transform: Transform::from_xyz(offset_x, -offset_y, offset_z),
+                            transform: match &tiled_settings.map_positioning {
+                                MapPositioning::LayerOffset => {
+                                    Transform::from_xyz(offset_x, -offset_y, offset_z)
+                                }
+                                MapPositioning::Centered => {
+                                    get_tilemap_center_transform(
+                                        &map_size,
+                                        &grid_size,
+                                        &map_type,
+                                        layer_index as f32,
+                                    ) * Transform::from_xyz(offset_x, -offset_y, offset_z)
+                                }
+                            },
                             map_type,
                             render_settings: *render_settings,
                             ..Default::default()

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -10,4 +10,18 @@ pub struct TiledMapSettings {
     pub collision_layer_names: ObjectNames,
     /// Specify which tileset object names to add collision shapes for.
     pub collision_object_names: ObjectNames,
+    /// Specify which position transformation offset should be applied.
+    ///
+    /// By default, the layer's offset will be used.
+    /// For Bevy's coordinate system use MapPositioning::Centered
+    pub map_positioning: MapPositioning,
+}
+
+#[derive(Default, Clone)]
+pub enum MapPositioning {
+    #[default]
+    /// Transforms TilemapBundle starting from the layer's offset.
+    LayerOffset,
+    /// Mimics Bevy's coordinate system so that (0, 0) is at the center of the map.
+    Centered,
 }


### PR DESCRIPTION
Didn't want to re-write all of the camera, player spawn point, etc. transformations due to not being able to "shift" the board to Bevy's coordinates. Most, if not all, examples from `bevy_ecs_tilemap` uses the `get_tlemap_center_transform` method within their examples (for example: https://github.com/StarArawn/bevy_ecs_tilemap/blob/1f1d46f3456e880145ca92597a8ce48666ea393f/examples/basic.rs#L59)